### PR TITLE
Fixed jss-without-preset benchmark

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cxs": "^2.1.0",
     "glamor": "^2.18.2",
     "jss": "^5.5.6",
+    "jss-camel-case": "^2.0.2",
     "jss-preset-default": "^0.8.0",
     "rimraf": "^2.5.4",
     "webpack": "^1.13.3"

--- a/src/classes-overload-test/cases/jss-without-preset.js
+++ b/src/classes-overload-test/cases/jss-without-preset.js
@@ -1,9 +1,11 @@
 import { create } from 'jss';
+import camelCase from 'jss-camel-case';
 import { renderHtml } from './render';
 import { generateStyles } from '../styles';
 
 export const jssWithoutPresetCase = () => {
     const jss = create();
+    jss.use(camelCase());
 
     const { classes } = jss.createStyleSheet(generateStyles()).attach();
 

--- a/src/simple-test/cases/jss-without-preset.js
+++ b/src/simple-test/cases/jss-without-preset.js
@@ -1,9 +1,11 @@
 import { create } from 'jss';
+import camelCase from 'jss-camel-case';
 import { renderHtml } from './render';
 import { styles } from '../styles';
 
 export const jssWithoutPresetCase = () => {
     const jss = create();
+    jss.use(camelCase());
 
     const { classes: { container, button } } = jss.createStyleSheet(styles).attach();
 

--- a/src/size-test/jss-without-preset.js
+++ b/src/size-test/jss-without-preset.js
@@ -1,1 +1,2 @@
 import jss from 'jss';
+import camelCase from 'jss-camel-case';

--- a/src/style-overload-test/cases/jss-without-preset.js
+++ b/src/style-overload-test/cases/jss-without-preset.js
@@ -1,9 +1,11 @@
 import { create } from 'jss';
+import camelCase from 'jss-camel-case';
 import { renderHtml } from './render';
 import { generateStyles } from '../styles';
 
 export const jssWithoutPresetCase = () => {
     const jss = create();
+    jss.use(camelCase());
 
     const { classes } = jss.createStyleSheet(generateStyles()).attach();
 


### PR DESCRIPTION
Before this PR, the generated CSS was actually like this:
```css
.container-1084111492 {
  backgroundColor: blue;
  textAlign: center;
  padding: 50;
}
.button-114565468 {
  backgroundColor: red;
  fontSize: 30;
  border: 3px solid yellow;
}
```

This PR adds the necessary https://github.com/cssinjs/jss-camel-case plugin so the generated CSS will function correctly.