### PR TITLE
Added styletron to benchmarks

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "jss-camel-case": "^2.0.2",
     "jss-preset-default": "^0.8.0",
     "rimraf": "^2.5.4",
+    "styletron-client": "^2.1.1",
+    "styletron-server": "^2.1.1",
+    "styletron-utils": "^2.1.0",
     "webpack": "^1.13.3"
   },
   "devDependencies": {

--- a/src/classes-overload-test/cases/index.js
+++ b/src/classes-overload-test/cases/index.js
@@ -4,3 +4,4 @@ export * from './glamor';
 export * from './jss-without-preset';
 export * from './cxs';
 export * from './cxs-optimized';
+export * from './styletron';

--- a/src/classes-overload-test/cases/styletron.js
+++ b/src/classes-overload-test/cases/styletron.js
@@ -1,0 +1,23 @@
+import Styletron from 'styletron-server';
+import { injectStyle } from 'styletron-utils';
+import { renderHtml } from '../render';
+import { containerStyle, buttonStyles } from '../styles';
+
+export const styletronCase = () => {
+    const styletron = new Styletron();
+
+    const getButtonClassName = i => injectStyle(styletron, buttonStyles[i]);
+
+    const html = renderHtml(injectStyle(styletron, containerStyle), getButtonClassName);
+
+    const css = styletron.getCss();
+
+    return `
+        <html>
+            <head>
+                <style type="text/css">${css}</style>
+            </head>
+            <body>${html}</body>
+        </html>
+    `;
+};

--- a/src/classes-overload-test/index.js
+++ b/src/classes-overload-test/index.js
@@ -1,6 +1,6 @@
 import { Suite } from 'benchmark';
 import beautifyBenchmark from 'beautify-benchmark';
-import { aphroditeCase, jssCase, glamorCase, jssWithoutPresetCase, cxsCase, cxsOptimizedCase } from './cases';
+import { aphroditeCase, jssCase, glamorCase, jssWithoutPresetCase, cxsCase, cxsOptimizedCase, styletronCase } from './cases';
 
 export const run = () => {
     console.log('Running classes overload test.');
@@ -11,6 +11,7 @@ export const run = () => {
     console.log('glamor length', glamorCase().length);
     console.log('cxs length', cxsCase().length);
     console.log('cxs-optimized length', cxsOptimizedCase().length);
+    console.log('styletron length', styletronCase().length);
 
     const jssSuite = new Suite();
 
@@ -20,6 +21,7 @@ export const run = () => {
     jssSuite.add('glamor', () => glamorCase());
     jssSuite.add('cxs', () => cxsCase());
     jssSuite.add('cxs-optimized', () => cxsOptimizedCase());
+    jssSuite.add('styletron', () => styletronCase());
 
     jssSuite.on('cycle', (e) => {
         beautifyBenchmark.add(e.target);

--- a/src/simple-test/cases/index.js
+++ b/src/simple-test/cases/index.js
@@ -4,3 +4,4 @@ export * from './glamor';
 export * from './jss-without-preset';
 export * from './cxs';
 export * from './cxs-optimized';
+export * from './styletron';

--- a/src/simple-test/cases/styletron.js
+++ b/src/simple-test/cases/styletron.js
@@ -1,0 +1,24 @@
+import Styletron from 'styletron-server';
+import { injectStyle } from 'styletron-utils';
+import { renderHtml } from '../render';
+import { containerStyle, buttonStyle } from '../styles';
+
+export const styletronCase = () => {
+    const styletron = new Styletron();
+
+    const html = renderHtml(
+        injectStyle(styletron, containerStyle),
+        injectStyle(styletron, buttonStyle)
+    );
+
+    const css = styletron.getCss();
+
+    return `
+        <html>
+            <head>
+                <style type="text/css">${css}</style>
+            </head>
+            <body>${html}</body>
+        </html>
+    `;
+};

--- a/src/simple-test/index.js
+++ b/src/simple-test/index.js
@@ -1,6 +1,6 @@
 import { Suite } from 'benchmark';
 import beautifyBenchmark from 'beautify-benchmark';
-import { aphroditeCase, jssCase, glamorCase, jssWithoutPresetCase, cxsCase, cxsOptimizedCase } from './cases';
+import { aphroditeCase, jssCase, glamorCase, jssWithoutPresetCase, cxsCase, cxsOptimizedCase, styletronCase } from './cases';
 
 export const run = () => {
     console.log('Running simple test.');
@@ -11,6 +11,7 @@ export const run = () => {
     console.log('glamor length', glamorCase().length);
     console.log('cxs length', cxsCase().length);
     console.log('cxs-optimized length', cxsOptimizedCase().length);
+    console.log('styletron length', styletronCase().length);
 
     const jssSuite = new Suite();
 
@@ -20,6 +21,7 @@ export const run = () => {
     jssSuite.add('glamor', () => glamorCase());
     jssSuite.add('cxs', () => cxsCase());
     jssSuite.add('cxs-optimized', () => cxsOptimizedCase());
+    jssSuite.add('styletron', () => styletronCase());
 
     jssSuite.on('cycle', (e) => {
         beautifyBenchmark.add(e.target);

--- a/src/size-test/index.js
+++ b/src/size-test/index.js
@@ -61,6 +61,7 @@ Promise.all([
     testBundle('glamor'),
     testBundle('jss-without-preset'),
     testBundle('jss'),
+    testBundle('styletron'),
 ]).then(() => {
     rimraf(path.join(__dirname, 'dist'), (err) => {
         if (err) {

--- a/src/size-test/styletron.js
+++ b/src/size-test/styletron.js
@@ -1,0 +1,2 @@
+import StyletronClient from 'styletron-client';
+import injectStyle from 'styletron-utils/lib/inject-style';

--- a/src/style-overload-test/cases/index.js
+++ b/src/style-overload-test/cases/index.js
@@ -4,3 +4,4 @@ export * from './glamor';
 export * from './jss-without-preset';
 export * from './cxs';
 export * from './cxs-optimized';
+export * from './styletron';

--- a/src/style-overload-test/cases/styletron.js
+++ b/src/style-overload-test/cases/styletron.js
@@ -1,0 +1,23 @@
+import Styletron from 'styletron-server';
+import { injectStyle } from 'styletron-utils';
+import { renderHtml } from '../render';
+import { containerStyle, buttonStyles } from '../styles';
+
+export const styletronCase = () => {
+    const styletron = new Styletron();
+
+    const getButtonClassName = i => injectStyle(styletron, buttonStyles[i]);
+
+    const html = renderHtml(injectStyle(styletron, containerStyle), getButtonClassName);
+
+    const css = styletron.getCss();
+
+    return `
+        <html>
+            <head>
+                <style type="text/css">${css}</style>
+            </head>
+            <body>${html}</body>
+        </html>
+    `;
+};

--- a/src/style-overload-test/index.js
+++ b/src/style-overload-test/index.js
@@ -1,6 +1,6 @@
 import { Suite } from 'benchmark';
 import beautifyBenchmark from 'beautify-benchmark';
-import { aphroditeCase, jssCase, glamorCase, jssWithoutPresetCase, cxsCase, cxsOptimizedCase } from './cases';
+import { aphroditeCase, jssCase, glamorCase, jssWithoutPresetCase, cxsCase, cxsOptimizedCase, styletronCase } from './cases';
 
 export const run = () => {
     console.log('Running styles overload test.');
@@ -11,6 +11,7 @@ export const run = () => {
     console.log('glamor length', glamorCase().length);
     console.log('cxs length', cxsCase().length);
     console.log('cxs-optimized length', cxsOptimizedCase().length);
+    console.log('styletron length', styletronCase().length);
 
     const jssSuite = new Suite();
 
@@ -20,6 +21,7 @@ export const run = () => {
     jssSuite.add('glamor', () => glamorCase());
     jssSuite.add('cxs', () => cxsCase());
     jssSuite.add('cxs-optimized', () => cxsOptimizedCase());
+    jssSuite.add('styletron', () => styletronCase());
 
     jssSuite.on('cycle', (e) => {
         beautifyBenchmark.add(e.target);


### PR DESCRIPTION
Added https://github.com/rtsao/styletron to benchmarks.

**System specs**

```
❯ node -v
v7.2.0

❯ /usr/sbin/system_profiler SPHardwareDataType
Hardware:

    Hardware Overview:

      Model Name: MacBook Pro
      Model Identifier: MacBookPro11,3
      Processor Name: Intel Core i7
      Processor Speed: 2.3 GHz
      Number of Processors: 1
      Total Number of Cores: 4
      L2 Cache (per Core): 256 KB
      L3 Cache: 6 MB
      Memory: 16 GB
```

**Results**

```
> css-in-js-perf-tests@1.0.0 bench:simple-test /Users/rtsao/css-in-js-perf-tests
> node lib/simple-test


Running simple test.
aphrodite length 470
jss length 447
jss-without-preset length 443
glamor length 428
cxs length 400
cxs-optimized length 445
styletron length 366
  7 tests completed.

  aphrodite          x  17,916 ops/sec ±0.81% (85 runs sampled)
  jss                x  33,280 ops/sec ±1.30% (85 runs sampled)
  jss-without-preset x  47,705 ops/sec ±1.27% (86 runs sampled)
  glamor             x  13,879 ops/sec ±1.03% (86 runs sampled)
  cxs                x  36,208 ops/sec ±1.37% (85 runs sampled)
  cxs-optimized      x  27,695 ops/sec ±1.32% (84 runs sampled)
  styletron          x 114,256 ops/sec ±0.88% (88 runs sampled)

Fastest is: styletron


> css-in-js-perf-tests@1.0.0 bench:style-overload-test /Users/rtsao/css-in-js-perf-tests
> node lib/style-overload-test


Running styles overload test.
aphrodite length 2868
jss length 2783
jss-without-preset length 2745
glamor length 2572
cxs length 2296
cxs-optimized length 2337
styletron length 1370
  7 tests completed.

  aphrodite          x  2,265 ops/sec ±0.74% (84 runs sampled)
  jss                x  4,838 ops/sec ±1.50% (87 runs sampled)
  jss-without-preset x  6,486 ops/sec ±1.19% (88 runs sampled)
  glamor             x  1,700 ops/sec ±1.39% (84 runs sampled)
  cxs                x  4,058 ops/sec ±1.16% (88 runs sampled)
  cxs-optimized      x  3,239 ops/sec ±1.30% (85 runs sampled)
  styletron          x 17,998 ops/sec ±1.18% (86 runs sampled)

Fastest is: styletron


> css-in-js-perf-tests@1.0.0 bench:classes-overload-test /Users/rtsao/css-in-js-perf-tests
> node lib/classes-overload-test


Running classes overload test.
aphrodite length 2318
jss length 2359
jss-without-preset length 2359
glamor length 1206
cxs length 1217
cxs-optimized length 1217
styletron length 960
  7 tests completed.

  aphrodite          x  3,424 ops/sec ±0.71% (83 runs sampled)
  jss                x  6,999 ops/sec ±1.58% (82 runs sampled)
  jss-without-preset x  8,737 ops/sec ±0.86% (88 runs sampled)
  glamor             x  6,241 ops/sec ±0.86% (86 runs sampled)
  cxs                x  6,107 ops/sec ±0.98% (84 runs sampled)
  cxs-optimized      x  5,084 ops/sec ±1.02% (87 runs sampled)
  styletron          x 42,475 ops/sec ±1.94% (85 runs sampled)

Fastest is: styletron
```