### PR TITLE
Bump styletron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "jss-nested": "^2.5.0",
     "jss-preset-default": "^0.8.0",
     "rimraf": "^2.5.4",
-    "styletron-client": "^2.1.1",
-    "styletron-server": "^2.1.1",
-    "styletron-utils": "^2.1.0",
+    "styletron-client": "^2.3.0",
+    "styletron-server": "^2.3.0",
+    "styletron-utils": "^2.3.0",
     "webpack": "^1.13.3"
   },
   "devDependencies": {


### PR DESCRIPTION
v2.3.0 has improved performance (and included TypeScript definitions)


<details>
<summary>Benchmarks</summary>

```
Running simple test.

aphrodite length 582.
aphrodite-no-important length 472
cssobj length 636
cxs length 552
cxs-optimized length 634
fela length 421
free-style length 521
glamor length 591
j2c length 743
jss length 636
jss-without-preset length 636
styletron length 502

Smallest is: fela


  aphrodite              x   8,266 ops/sec ±0.70% (85 runs sampled)
  aphrodite-no-important x   8,841 ops/sec ±1.47% (84 runs sampled)
  cssobj                 x   4,941 ops/sec ±0.92% (85 runs sampled)
  cxs                    x  11,112 ops/sec ±1.08% (87 runs sampled)
  cxs-optimized          x   8,494 ops/sec ±1.20% (88 runs sampled)
  fela                   x  79,756 ops/sec ±1.23% (87 runs sampled)
  free-style             x  19,325 ops/sec ±1.20% (89 runs sampled)
  glamor                 x   6,059 ops/sec ±1.00% (88 runs sampled)
  j2c                    x  26,789 ops/sec ±1.62% (88 runs sampled)
  jss                    x  20,823 ops/sec ±1.57% (86 runs sampled)
  jss-without-preset     x  30,441 ops/sec ±0.77% (88 runs sampled)
  styletron              x 117,248 ops/sec ±2.35% (88 runs sampled)

Fastest is: styletron


Running nested test.

aphrodite length 1179
aphrodite-no-important length 926
cssobj length 1100
cxs length 975
cxs-optimized length 1061
fela length 800
free-style length 802
glamor length 1479
j2c length 1350
jss length 1089
jss-without-preset length 1089
styletron length 790

Smallest is: styletron


  aphrodite              x  3,564 ops/sec ±0.65% (83 runs sampled)
  aphrodite-no-important x  3,921 ops/sec ±1.00% (88 runs sampled)
  cssobj                 x  1,927 ops/sec ±2.14% (81 runs sampled)
  cxs                    x  5,372 ops/sec ±1.29% (88 runs sampled)
  cxs-optimized          x  4,561 ops/sec ±1.05% (85 runs sampled)
  fela                   x 25,156 ops/sec ±1.04% (87 runs sampled)
  free-style             x  6,944 ops/sec ±2.14% (84 runs sampled)
  glamor                 x  2,413 ops/sec ±2.33% (79 runs sampled)
  j2c                    x 15,088 ops/sec ±1.02% (87 runs sampled)
  jss                    x  5,779 ops/sec ±1.66% (87 runs sampled)
  jss-without-preset     x  7,008 ops/sec ±1.79% (85 runs sampled)
  styletron              x 37,948 ops/sec ±1.42% (87 runs sampled)

Fastest is: styletron


Running style overload test.

aphrodite length 3537
aphrodite-no-important length 2866
cssobj length 3207
cxs length 2757
cxs-optimized length 2874
fela length 1528
free-style length 2491
glamor length 3034
j2c length 4320
jss length 3318
jss-without-preset length 3318
styletron length 1549

Smallest is: fela


  aphrodite              x  1,215 ops/sec ±0.51% (87 runs sampled)
  aphrodite-no-important x  1,307 ops/sec ±1.29% (87 runs sampled)
  cssobj                 x    899 ops/sec ±1.99% (85 runs sampled)
  cxs                    x  1,988 ops/sec ±0.39% (89 runs sampled)
  cxs-optimized          x  1,474 ops/sec ±1.30% (86 runs sampled)
  fela                   x 17,412 ops/sec ±1.29% (89 runs sampled)
  free-style             x  2,985 ops/sec ±1.22% (87 runs sampled)
  glamor                 x  1,117 ops/sec ±0.94% (87 runs sampled)
  j2c                    x  4,450 ops/sec ±2.52% (89 runs sampled)
  jss                    x  4,451 ops/sec ±1.62% (85 runs sampled)
  jss-without-preset     x  5,719 ops/sec ±1.51% (89 runs sampled)
  styletron              x 24,425 ops/sec ±1.46% (87 runs sampled)

Fastest is: styletron


Running classes overload test.

aphrodite length 2955
aphrodite-no-important length 2504
cssobj length 2795
cxs length 1334
cxs-optimized length 1713
fela length 1078
free-style length 1173
glamor length 1283
j2c length 3992
jss length 2896
jss-without-preset length 2896
styletron length 1099

Smallest is: fela


  aphrodite              x  1,596 ops/sec ±0.42% (86 runs sampled)
  aphrodite-no-important x  1,700 ops/sec ±1.25% (87 runs sampled)
  cssobj                 x  1,116 ops/sec ±1.39% (88 runs sampled)
  cxs                    x  2,804 ops/sec ±1.18% (87 runs sampled)
  cxs-optimized          x  2,064 ops/sec ±1.23% (87 runs sampled)
  fela                   x 39,699 ops/sec ±1.22% (85 runs sampled)
  free-style             x  3,768 ops/sec ±1.32% (85 runs sampled)
  glamor                 x  4,182 ops/sec ±1.29% (88 runs sampled)
  j2c                    x  5,138 ops/sec ±1.45% (87 runs sampled)
  jss                    x  5,465 ops/sec ±1.47% (85 runs sampled)
  jss-without-preset     x  7,147 ops/sec ±1.23% (88 runs sampled)
  styletron              x 57,558 ops/sec ±1.19% (89 runs sampled)

Fastest is: styletron
```
</details>