### PR TITLE
Fixed the way ENV variable for iterations are read

### DIFF
--- a/src/classes-overload-test/iterations.js
+++ b/src/classes-overload-test/iterations.js
@@ -1,1 +1,1 @@
-export const ITERATIONS = process.env.ITERATIONS || 20;
+export const ITERATIONS = parseInt(process.env.ITERATIONS, 10) || 20;

--- a/src/style-overload-test/iterations.js
+++ b/src/style-overload-test/iterations.js
@@ -1,1 +1,1 @@
-export const ITERATIONS = process.env.ITERATIONS || 20;
+export const ITERATIONS = parseInt(process.env.ITERATIONS, 10) || 20;


### PR DESCRIPTION
ITERATIONS is not always a number, so doing a parseInt.

P.S: I am trying to create a runtime benchmark for CSS-in-JS, aka trying to record Chrome timeline metrics like paint, layouts, styling, etc for each of the cases and hence wanted the page to be really big to show differences. 