### PR TITLE
Resolve a promise once instead of for each case

### DIFF
--- a/src/run.js
+++ b/src/run.js
@@ -62,15 +62,9 @@ export const runView = (testName, cases) => (
         Object.keys(testCases).forEach((caseName) => {
             const html = testCases[caseName].testCase(pad(caseName));
             const path = `${outputDir}/${caseName}.html`;
-            fs.writeFile(path, html, (err) => {
-                if (err) {
-                    console.error(err);
-                    reject(err);
-                } else {
-                    console.log(`Wrote ${path}`);
-                    resolve(path);
-                }
-            });
+            fs.writeFileSync(path, html);
+            console.log(`Wrote ${path}`);
         });
+        resolve(outputDir);
     })
 );


### PR DESCRIPTION
Currently, the promise is resolved multiple times, once for every file written. it should ideally resolve like the run benchmark case - only once for all the cases.

In this commit, the promise is rejected on the first error encountered